### PR TITLE
Firefox 36 added an 8th arg in the middle of saveURI

### DIFF
--- a/src/chrome/content/ImageDownload.js
+++ b/src/chrome/content/ImageDownload.js
@@ -220,7 +220,13 @@ com.neocodenetworks.faextender.ImageDownload = {
 
 			var privacyContext = doc.defaultView.QueryInterface(Components.interfaces.nsIInterfaceRequestor).getInterface(Components.interfaces.nsIWebNavigation).QueryInterface(Components.interfaces.nsILoadContext);
 
-			persist.saveURI(uri, cachekey, referrer, null, null, tempObject, privacyContext);
+
+			// Firefox 36 added an 8th arg in the middle of saveURI
+			if (persist.saveURI.length < 8) {
+				persist.saveURI(uri, cachekey, referrer, null, null, tempObject, privacyContext);
+                        } else {
+				persist.saveURI(uri, cachekey, referrer, null, null, null, tempObject, privacyContext);
+                        }
 		}
 		catch(err) {
 			com.neocodenetworks.faextender.Base.logException(err);


### PR DESCRIPTION
This should fix issue 32, download not working in Firefox 36.
I tested it on Firefox 36, I haven't tested it on Firefox 35, but it should work in either.
